### PR TITLE
Add ARM aarch64 support to dispatcher

### DIFF
--- a/dispatcher/linux/mfxloader.cpp
+++ b/dispatcher/linux/mfxloader.cpp
@@ -28,6 +28,9 @@ namespace MFX {
 #elif defined(__x86_64__)
     #define LIBMFXSW "libvplswref64.so.1"
     #define LIBMFXHW "libmfxhw64.so.1"
+#elif defined(__aarch64__)
+    #define LIBMFXSW "libvplswrefaarch64.so.1"
+    #define LIBMFXHW "libmfxhwaarch64.so.1"
 #else
     #error Unsupported architecture
 #endif

--- a/docker/build_docker_images.sh
+++ b/docker/build_docker_images.sh
@@ -11,5 +11,9 @@ docker build -f ${BASEDIR}/Dockerfile-rhel-8 -t vpl:rhel8 ${BASEDIR}/..
 docker build -f ${BASEDIR}/Dockerfile-centos-7 -t vpl:centos7 ${BASEDIR}/..
 docker build -f ${BASEDIR}/Dockerfile-centos-8 -t vpl:centos8 ${BASEDIR}/..
 docker build -f ${BASEDIR}/Dockerfile-ubuntu-18.04 -t vpl:ubuntu18.04 ${BASEDIR}/..
-docker build -f ${BASEDIR}/Dockerfile-ubuntu-19.10 -t vpl:ubuntu19.10 ${BASEDIR}/..
+
+if [ "$(uname -m)" == "x86_64" ]; then
+  docker build -f ${BASEDIR}/Dockerfile-ubuntu-19.10 -t vpl:ubuntu19.10 ${BASEDIR}/..
+fi
+
 docker build -f ${BASEDIR}/Dockerfile-ubuntu-20.04 -t vpl:ubuntu20.04 ${BASEDIR}/..


### PR DESCRIPTION
Signed-off-by: William Dean <wd13384@gmail.com>

Tested on Apple M1 with oneVPL provided docker files (except Ubuntu 19.10, which does not appear to support aarch64 in docker hub)