### PR TITLE
Fixed the issue that redundant pixel(s) would be written to output file.

### DIFF
--- a/examples/hello/hello-decode/src/util.h
+++ b/examples/hello/hello-decode/src/util.h
@@ -545,8 +545,8 @@ mfxStatus WriteRawFrame(mfxFrameSurface1 *surface, FILE *f) {
     mfxFrameInfo *info = &surface->Info;
     mfxFrameData *data = &surface->Data;
 
-    w = info->Width;
-    h = info->Height;
+    w = info->CropW;
+    h = info->CropH;
 
     // write the output to disk
     switch (info->FourCC) {


### PR DESCRIPTION
Fixes Issue #66.

When the bitstream was encoded with width or height aligned.

Signed-off-by: Austin Hu <austin.hu@intel.com>