### PR TITLE
replace PATH_MAX with realpath in dispatcher_util test

### DIFF
--- a/dispatcher/test/unit/src/dispatcher_util.cpp
+++ b/dispatcher/test/unit/src/dispatcher_util.cpp
@@ -145,12 +145,12 @@ int CreateWorkingDirectory(const char *dirPath) {
         closedir(workDir);
     }
 
-    // convert to canonical, absolute path (limited to PATH_MAX bytes per manual)
-    char fullPath[PATH_MAX] = {};
-    char *t = realpath(workDirPath.c_str(), fullPath);
-    if (!t || t != fullPath)
+    // convert to canonical, absolute path
+    char *fullPath = realpath(workDirPath.c_str(), NULL);
+    if (!fullPath)
         return -1;
-    workDirPath = fullPath;
+    workDirPath = fullPath; // copy to std::string
+    free(fullPath);
 #endif
 
     // success - store working directory in global path


### PR DESCRIPTION
Was not building for a CI musl build. Undefined `PATH_MAX`, defined in linux/limits.h.