### PR TITLE
Remove broken workaround for ILP32 detection on ARM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,13 +44,6 @@ if(MSVC)
   endif()
 endif()
 
-# WA for missing definition in 32-bit arm-linux compiler
-string(FIND ${CMAKE_CXX_COMPILER} "arm-linux" IS_ARM_32BIT)
-if(${IS_ARM_32BIT} GREATER_EQUAL 0)
-  message(STATUS "Setting __ILP32__")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D__ILP32__")
-endif()
-
 # Project options
 option(BUILD_SHARED_LIBS "Build shared instead of static libraries." ON)
 option(BUILD_TESTS "Build tests." OFF)


### PR DESCRIPTION
Matching the compiler filesystem path with some quite arbitrary string like `arm-linux` is broken. It will not match a host compiler path like `/usr/bin/c++`, but may even erroneously match on other architectures.

Second, while it may be possible to make injecting an __ILP32__ define work, it requires the same workaround in every downstream user.