### PR TITLE
[Samples] Fix "dGfx" option for Linux

### DIFF
--- a/tools/legacy/sample_decode/src/pipeline_decode.cpp
+++ b/tools/legacy/sample_decode/src/pipeline_decode.cpp
@@ -1136,6 +1136,10 @@ mfxStatus CDecodingPipeline::CreateHWDevice() {
     defined(LIBVA_ANDROID_SUPPORT) || defined(LIBVA_WAYLAND_SUPPORT)
     mfxStatus sts = MFX_ERR_NONE;
 
+    if (m_strDevicePath.empty()) {
+        m_strDevicePath = "/dev/dri/renderD" + std::to_string(m_pLoader->GetDRMRenderNodeNumUsed());
+    }
+
     m_hwdev = CreateVAAPIDevice(m_strDevicePath, m_libvaBackend);
 
     if (NULL == m_hwdev) {

--- a/tools/legacy/sample_encode/src/pipeline_encode.cpp
+++ b/tools/legacy/sample_encode/src/pipeline_encode.cpp
@@ -958,6 +958,9 @@ mfxStatus CEncodingPipeline::CreateHWDevice() {
     MSDK_CHECK_STATUS(sts, "m_hwdev->Init failed");
 
 #elif LIBVA_SUPPORT
+    if (m_strDevicePath.empty()) {
+        m_strDevicePath = "/dev/dri/renderD" + std::to_string(m_pLoader->GetDRMRenderNodeNumUsed());
+    }
 
     m_hwdev = CreateVAAPIDevice(m_strDevicePath);
 

--- a/tools/legacy/sample_multi_transcode/src/sample_multi_transcode.cpp
+++ b/tools/legacy/sample_multi_transcode/src/sample_multi_transcode.cpp
@@ -352,6 +352,10 @@ mfxStatus Launcher::Init(int argc, char* argv[]) {
                     libvaBackend         = params.libvaBackend;
 
                     /* Rendering case */
+                    if (InputParams.strDevicePath.empty()) {
+                        InputParams.strDevicePath = "/dev/dri/renderD" + std::to_string(m_pLoader->GetDRMRenderNodeNumUsed());
+                    }
+
                     hwdev.reset(CreateVAAPIDevice(InputParams.strDevicePath, params.libvaBackend));
                     if (!hwdev.get()) {
                         printf("error: failed to initialize VAAPI device\n");
@@ -405,6 +409,10 @@ mfxStatus Launcher::Init(int argc, char* argv[]) {
                 }
                 else /* NO RENDERING*/
                 {
+                    if (m_InputParamsArray[i].strDevicePath.empty()) {
+                        m_InputParamsArray[i].strDevicePath = "/dev/dri/renderD" + std::to_string(m_pLoader->GetDRMRenderNodeNumUsed());
+                    }
+
                     hwdev.reset(CreateVAAPIDevice(m_InputParamsArray[i].strDevicePath));
 
                     if (!hwdev.get()) {

--- a/tools/legacy/sample_vpp/src/sample_vpp_utils.cpp
+++ b/tools/legacy/sample_vpp/src/sample_vpp_utils.cpp
@@ -704,6 +704,10 @@ mfxStatus InitMemoryAllocator(sFrameProcessor* pProcessor,
         }
         else if ((pInParams->ImpLib & IMPL_VIA_MASK) == MFX_IMPL_VIA_VAAPI) {
 #ifdef LIBVA_SUPPORT
+            if (pInParams->strDevicePath.empty()) {
+                pInParams->strDevicePath = "/dev/dri/renderD" + std::to_string(pProcessor->pLoader->GetDRMRenderNodeNumUsed());
+            }
+
             pAllocator->pDevice = CreateVAAPIDevice(pInParams->strDevicePath);
             MSDK_CHECK_POINTER(pAllocator->pDevice, MFX_ERR_NULL_PTR);
 
@@ -742,6 +746,10 @@ mfxStatus InitMemoryAllocator(sFrameProcessor* pProcessor,
         pProcessor->mfxSession.QueryIMPL(&impl);
 
         if (MFX_IMPL_HARDWARE == MFX_IMPL_BASETYPE(impl)) {
+            if (pInParams->strDevicePath.empty()) {
+                pInParams->strDevicePath = "/dev/dri/renderD" + std::to_string(pProcessor->pLoader->GetDRMRenderNodeNumUsed());
+            }
+
             pAllocator->pDevice = CreateVAAPIDevice(pInParams->strDevicePath);
             if (!pAllocator->pDevice)
                 sts = MFX_ERR_MEMORY_ALLOC;


### PR DESCRIPTION
[Issue]
`-dGfx` option doesn't result in discrete GPU selection for iGPU + dGPU setup. This is because when device path (`/dev/dri/renderD12<x>`) is not being specified, it always fallback to the first intel adapter found, which is `/dev/dri/renderD128` in iGPU + dGPU setup.

[Solution]
If device path is not being explicitly specified, set it to `m_DRMRenderNodeNumUsed`

[Dependency]
https://github.com/oneapi-src/oneVPL-intel-gpu/pull/301