### PR TITLE
Add support for multiple GPUs on Windows

### DIFF
--- a/libvpl/src/windows/mfx_library_iterator.cpp
+++ b/libvpl/src/windows/mfx_library_iterator.cpp
@@ -619,9 +619,13 @@ mfxStatus MFXLibraryIterator::GetRegkeyDir(std::wstring &regDir, size_t length, 
     mfxStatus sts = MFX_ERR_UNSUPPORTED;
     MFX::MFXLibraryIterator libIterator;
     wchar_t wRegDir[MFX_MAX_DLL_PATH];
+    int adapterNum = 0;
 
     regDir.clear();
-    sts = libIterator.Init(MFX_LIB_HARDWARE, MFX_IMPL_VIA_D3D11, 0, storageID);
+    do {
+        sts = libIterator.Init(MFX_LIB_HARDWARE, MFX_IMPL_VIA_D3D11, adapterNum, storageID);
+        adapterNum++;
+    } while (sts == MFX_ERR_NONE && !libIterator.isIntelAdapter());
     if (sts)
         return MFX_ERR_UNSUPPORTED;
 

--- a/libvpl/src/windows/mfx_library_iterator.h
+++ b/libvpl/src/windows/mfx_library_iterator.h
@@ -99,6 +99,9 @@ public:
                                        mfxU32 deviceID,
                                        int storageID);
     static mfxStatus GetRegkeyDir(std::wstring &regDir, size_t length, int storageID);
+    bool isIntelAdapter() const {
+        return m_vendorID == INTEL_VENDOR_ID;
+    }
 
 protected:
     // Release the iterator


### PR DESCRIPTION
If the primary GPU is not an Intel GPU, libvpl cannot detect the Intel GPU in the Windows environment, even though it is present. The situation is, for example, using an NVIDIA graphics card with an Intel CPU that has an embedded GPU. This patch allows the Intel GPU to be detected in such situations.

## Issue
When a GPU of other than Intel is primary, the Intel GPU fails to be detected by libvpl for MFX API.
<!---
Describe the problem your changes address as well as a link to the corresponding issue.
-->


## Solution

Search Intel GPU (vendor ID == 0x8086) whose adapterNum is other than 0 in `MFXLibraryIterator::GetRegkeyDir()`.
<!--- Provide a high level overview of how this submission addresses the issue -->

## How Tested
Apply the proposed patch to cygwin libvpl package, and run `mpv -vd h264_qsv videofile.mp4` in my environment:
* Primary GPU: NVIDIA Geforce GTX 750Ti
* Secondary GPU: Intel HD Graphics 4600 (Core i7 4790)

100% tests passed for the test suites.
<!--- Explain what you did to test this Pull Request -->
