### PR TITLE
Allow older GPUs

### DIFF
--- a/libvpl/src/mfx_dispatcher_vpl_loader.cpp
+++ b/libvpl/src/mfx_dispatcher_vpl_loader.cpp
@@ -38,7 +38,7 @@ static const VPLFunctionDesc FunctionDescOptional[NumVPLOptionalFunctions] = {
 };
 
 static const VPLFunctionDesc MSDKCompatFunctions[NumMSDKFunctions] = {
-    { "MFXInitEx",                              { { 14, 1 } } },
+    { "MFXInit",                                { {  0, 1 } } },
     { "MFXClose" ,                              { {  0, 1 } } },
 };
 


### PR DESCRIPTION
Currently, the code in linux/mfxloader.cpp and windows/main.cpp supports initializing the GPU using the legacy MFXInit() if MFXInitEx() is not available.  However, the GPUs without MFXInitEx() are excluded by LoaderCtxVPL::CheckValidLibraries() in mfx_dispatcher_vp_loader.cpp. This inconsistency is addressed by this patch, which enables support for older GPUs without MFXInitEx().

Fixes: 17968d8d2299 ("Release 2021.2.2")

## Issue
libvpl does not work with Intel HD Graphics embedded in Celeron 1005M, which has H.264 decoding feature via MFX API.
<!---
Describe the problem your changes address as well as a link to the corresponding issue.
-->


## Solution
Check for the existence of `MFXInit()` instead of `MFXInitEx()` in `LoaderCtxVPL::CheckValidLibraries()`.
<!--- Provide a high level overview of how this submission addresses the issue -->

## How Tested
Apply the proposed patch to cygwin libvpl package and run `mpv -vd h264_qsv videofile.mp4` in my laptop with Celeron 1005M.

100% tests passed for the test suites.
<!--- Explain what you did to test this Pull Request -->
